### PR TITLE
docs: clarify supported formats in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build:
 3. sh build.sh
 
 Usage:
-* `AudioC()`: Pure front-end decoding and playback of audio without server support. The mainstream audio file formats supported by default include MP3, WAV, OGG, and AMR, and different browsers have different levels of support for these three formats. The MP3 format has the best support among them
+* `AudioC()`: Pure front-end decoding and playback of audio without server support. The mainstream audio file formats supported by default include MP3, WAV, OGG, and AMR. Different browsers offer varying levels of support for these four formats, with MP3 providing the best compatibility.
   * Usage: 
     ```js
     var audio = new AudioC();


### PR DESCRIPTION
## Summary
- fix README to reference four supported audio formats
- tighten wording around browser compatibility

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689992298604832fac23ce441c6cdb66