### PR TITLE
Fix AMR parameter defaulting

### DIFF
--- a/build/audioc.js
+++ b/build/audioc.js
@@ -222,8 +222,8 @@ var AMR = /*#__PURE__*/function () {
     _classCallCheck(this, AMR);
     !params && (params = {});
     this.params = params;
-    this.frame_size = 320 || params.frame_size;
-    this.ring_size = 2304 || params.ring_size;
+    this.frame_size = params.frame_size || 320;
+    this.ring_size = params.ring_size || 2304;
     this.linoffset = 0;
     this.ringoffset = 0;
     this.modoffset = 0;

--- a/src/audioc.js
+++ b/src/audioc.js
@@ -219,9 +219,9 @@
     constructor(params) {
       !params && (params = {});
       this.params = params;
-      this.frame_size = 320 || params.frame_size;
+      this.frame_size = params.frame_size || 320;
 
-      this.ring_size = 2304 || params.ring_size;
+      this.ring_size = params.ring_size || 2304;
 
       this.linoffset = 0;
 


### PR DESCRIPTION
## Summary
- allow AMR constructor to respect user-supplied frame and ring sizes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689994ad5030832f90a22d07c2e4aa28